### PR TITLE
AA-90: make description of permissions/roles editable

### DIFF
--- a/CMR/src/hibernate/Role.hbm.xml
+++ b/CMR/src/hibernate/Role.hbm.xml
@@ -7,6 +7,7 @@
 		</id>
 		
 		<property name="title" type="string" column="title" unique="true"></property>
+		<property name="description" type="string" column="description"></property>
 		
 		<list name="permissions" lazy="false">
 			<key column="id" />

--- a/CMR/src/info/novatec/inspectit/cmr/dao/PermissionDao.java
+++ b/CMR/src/info/novatec/inspectit/cmr/dao/PermissionDao.java
@@ -69,10 +69,10 @@ public interface PermissionDao {
 
 	/**
 	 * Returns a permission object with the same title as the parameter.
-	 * @param permission permission
+	 * @param title the title of the permission
 	 * @return a permission
 	 */
-	List<Permission> findByTitle(Permission permission);
+	Permission findByTitle(String title);
 	
 	/**
 	 * Searches for a Permission in the Database matching the example.

--- a/CMR/src/info/novatec/inspectit/cmr/dao/impl/PermissionDaoImpl.java
+++ b/CMR/src/info/novatec/inspectit/cmr/dao/impl/PermissionDaoImpl.java
@@ -96,10 +96,17 @@ public class PermissionDaoImpl extends HibernateDaoSupport implements Permission
 	 * {@inheritDoc}
 	 */
 	@SuppressWarnings("unchecked")
-	public List<Permission> findByTitle(Permission permission) {
+	public Permission findByTitle(String title) {
 		DetachedCriteria criteria = DetachedCriteria.forClass(Permission.class);
-		criteria.add(Restrictions.eq("title", permission.getTitle()));
-		return getHibernateTemplate().findByCriteria(criteria);
+		criteria.add(Restrictions.eq("title", title));
+		
+		List<Permission> result = getHibernateTemplate().findByCriteria(criteria);
+		
+		if (result.isEmpty()) {
+			return null;
+		} else {
+			return result.get(0);
+		}
 	}
 		
 	/**

--- a/CMR/src/info/novatec/inspectit/cmr/service/SecurityService.java
+++ b/CMR/src/info/novatec/inspectit/cmr/service/SecurityService.java
@@ -38,6 +38,7 @@ import info.novatec.inspectit.spring.logger.Log;
  * @author Clemens Geibel
  * @author Lucca Hellriegel
  * @author Mario Rose
+ * @author Joshua Hartmann
  */
 @Service
 public class SecurityService implements ISecurityService {
@@ -278,21 +279,26 @@ public class SecurityService implements ISecurityService {
 	}
 
 	// | PERMISSION |---------
+	
 	@Override
 	public void changePermissionDescription(Permission permission) {
-		List<Permission> foundPermissions = permissionDao.findByTitle(permission);
-		if (!checkDataIntegrity(permission)) {
-			throw new DataIntegrityViolationException("Data integrity test failed!");
-		} else if (foundPermissions.size() == 1) {
-			permissionDao.delete(foundPermissions.get(0));
-			permissionDao.saveOrUpdate(permission);
-		} else if (foundPermissions.size() > 1) {
-			throw new DataIntegrityViolationException("Multiple permissions with same title found!");
-		} else {
-			throw new DataRetrievalFailureException("The permission you wanted to update does not exist!");
-		}
+		changePermissionAttributes(permission, permission.getTitle(), permission.getDescription(), permission.getParameter());
 	}
 
+	@Override
+	public void changePermissionParameter(Permission permission) {
+		permissionDao.saveOrUpdate(permission);		
+	}	
+	
+	@Override
+	public void changePermissionAttributes(Permission perm, String newTitle, String newDescription, String newParamter) {
+		perm.setTitle(newTitle);
+		perm.setDescription(newDescription);
+		perm.setParameter(newParamter);
+		
+		permissionDao.saveOrUpdate(perm);
+	}
+	
 	@Override
 	public List<Permission> getAllPermissions() {
 		return permissionDao.loadAll();
@@ -338,28 +344,33 @@ public class SecurityService implements ISecurityService {
 				if (rolePermissions.get(i).equals(allPermissions.get(y).getTitle())) {
 					grantedPermissions.add(allPermissions.get(y));
 					break;
-					}
+				}
 			}
 		}
-	   Role role = new Role(name, grantedPermissions);
-		
-		
+		Role role = new Role(name, grantedPermissions);		
+			
 		if (!checkDataIntegrity(role)) {
 			throw new DataIntegrityViolationException("Data integrity test failed!");
 		}
 		List<Role> allRole = roleDao.loadAll();
 		if (allRole.contains(role)) {
 			throw new DataIntegrityViolationException("Role already exist!");
-		} else {
-			
+		} else {			
 			roleDao.saveOrUpdate(role);
 		}
 	}
 	
 	@Override
-	public void changeRoleAttribute(Role roleOld, String name, List<Permission> newPermissions) {
-		Role roleNew = new Role(roleOld.getId(), name, newPermissions);
-		roleDao.saveOrUpdate(roleNew);
+	public void changeRoleDescription(Role role, String newDescription)	{
+		changeRoleAttribute(role, role.getTitle(), newDescription, role.getPermissions());
+	}
+	
+	@Override
+	public void changeRoleAttribute(Role role, String newTitle, String newDescription, List<Permission> newPermissions) {
+		role.setTitle(newTitle);
+		role.setDescription(newDescription);
+		role.setPermissions(newPermissions);
+		roleDao.saveOrUpdate(role);
 	}
 	
 	@Override
@@ -368,10 +379,5 @@ public class SecurityService implements ISecurityService {
 	}
 
 
-	@Override
-	public void changePermissionParameter(Permission permission) {
-		permissionDao.saveOrUpdate(permission);
-		
-	}
 		// TODO Make more methods available for the administrator module...
 }

--- a/Commons/src/info/novatec/inspectit/communication/data/cmr/Permission.java
+++ b/Commons/src/info/novatec/inspectit/communication/data/cmr/Permission.java
@@ -95,7 +95,7 @@ public class Permission implements Serializable {
 	 */
 	@Override
 	public String toString() {
-		return "Permission [id=" + id + ", title=" + title + ", description=" + description + ", parameter=" + parameter + "]";
+		return "Permission [id=" + id + ", title='" + title + "', description='" + description + "', parameter='" + parameter + "']";
 	}
 	
 	/**  

--- a/Commons/src/info/novatec/inspectit/communication/data/cmr/Role.java
+++ b/Commons/src/info/novatec/inspectit/communication/data/cmr/Role.java
@@ -22,7 +22,12 @@ public class Role implements Serializable {
 	 * A short title to name the role.
 	 */
 	private String title;
-
+	
+	/**
+	 * A more detailed description for the role.
+	 */
+	private String description;
+	
 	/**
 	 * The id of the Role.
 	 */
@@ -47,6 +52,7 @@ public class Role implements Serializable {
 		this.permissions = permissions;
 		this.title = title;
 		this.id = id;
+		this.description = "";
 	}
 	/**
 	 * The constructor for a role.
@@ -58,6 +64,7 @@ public class Role implements Serializable {
 		this.permissions = permissions;
 		this.title = title;
 		this.id = 0;
+		this.description = "";
 	}	
 	/**
 	 * Gets {@link #permissions}.
@@ -84,11 +91,19 @@ public class Role implements Serializable {
 		return id;
 	}
 	/**
+	 * Gets {@link #description}.
+	 *   
+	 * @return {@link #description}  
+	 */
+	public String getDescription() {
+		return description;
+	}
+	/**
 	 * {@inheritDoc}
 	 */
 	@Override
 	public String toString() {
-		return "Role [permissions=" + getPermissions().toString() + ", title=" + title + ", id=" + id + "]";
+		return "Role [permissions=" + getPermissions().toString() + ", title='" + title + "', description='" + description + "', id=" + id + "]";
 	}
 	/**  
 	 * Sets {@link #permissions}.  
@@ -117,7 +132,14 @@ public class Role implements Serializable {
 	public void setId(long id) {
 		this.id = id;
 	}
-	
+	/**
+	 * Sets {@link #description}.
+	 * @param description
+	 * 						New value for {@link #description}
+	 */
+	public void setDescription(String description) {
+		this.description = description;
+	}
 	
 	
 }

--- a/CommonsCS/src/info/novatec/inspectit/cmr/service/ISecurityService.java
+++ b/CommonsCS/src/info/novatec/inspectit/cmr/service/ISecurityService.java
@@ -46,14 +46,6 @@ public interface ISecurityService {
 	 */
 	boolean existsSession(Serializable sessionId);
 
-	/**
-	 * Returns titles of permissions as Strings.
-	 * 
-	 * @param sessionId
-	 *            sessionId
-	 * @return List with the users permissions.
-	 */
-	List<Permission> getPermissions(Serializable sessionId);
 
 	// | ROLE | --------------
 	/**
@@ -64,7 +56,14 @@ public interface ISecurityService {
 	 * @return a Role object with given Email of the user.
 	 */
 	Role getRoleOfUser(String email);
-
+	
+	/**
+	 * Changes the description of the role, just a wrapper for changeRoleAttributes.
+	 * @param role the role to be changed
+	 * @param newDescription the new description
+	 */
+	void changeRoleDescription(Role role, String newDescription);
+	
 	/**
 	 * Searches for the Role matching a given ID.
 	 * 
@@ -90,15 +89,17 @@ public interface ISecurityService {
 	 */
 	void addRole(String name, List<String> rolePermissions);
 	/**
-	 * Method to edit a role.
-	 * @param roleOld
+	 * Method to edit the attributes of a role.
+	 * @param role
 	 * 		the role to edit
-	 * @param name
-	 * 		name of the new role
+	 * @param newDescription
+	 * 		new description of the role
+	 * @param newTitle
+	 * 		new title of the role
 	 * @param newPermissions
 	 * 		list of new permissions
 	 */
-	void changeRoleAttribute(Role roleOld, String name, List<Permission> newPermissions);
+	void changeRoleAttribute(Role role, String newTitle, String newDescription, List<Permission> newPermissions);
 	
 	/**
 	 * Deletes the given Role Object from the Database.
@@ -170,9 +171,19 @@ public interface ISecurityService {
 	 */
 	void changeUserAttribute(User userOld, String email, String password, long roleID, boolean passwordChanged, Serializable sessionId);
 
-	// | PERMISSION |---------
+	// | PERMISSION |---------	
+	
 	/**
-	 * Change the description of a Permission. Other changes should not be possible.
+	 * Changes all Attributes of the given Permission.
+	 * @param perm The Permission to be modified.
+	 * @param newTitle The new title of the permission.
+	 * @param newDescription The new description of the permission.
+	 * @param newParamter The new parameter of the permission.
+	 */
+	void changePermissionAttributes(Permission perm, String newTitle, String newDescription, String newParamter);
+	
+	/**
+	 * Change the description of a Permission. Other changes should not be possible, just a wrapper for changePermissionAttributes.
 	 * 
 	 * @param permission
 	 *            permission
@@ -187,15 +198,20 @@ public interface ISecurityService {
 	List<Permission> getAllPermissions();
 
 	/**
-	 * Changes the parameter for a permission.
+	 * Changes the parameter for a permission, just a wrapper for changePermissionAttributes.
 	 * @param permission
 	 * 				the permission with the actualized parameter.
 	 */
-	void changePermissionParameter(Permission permission);
+	void changePermissionParameter(Permission permission);	
 
-	
-
-	
+	/**
+	 * Returns titles of permissions as Strings.
+	 * 
+	 * @param sessionId
+	 *            sessionId
+	 * @return List with the users permissions.
+	 */
+	List<Permission> getPermissions(Serializable sessionId);
 
 }
 


### PR DESCRIPTION
-added description to roles
-added methods to change attributes of roles/permissions
-added methods to change the description of roles/permissions
-changed permissionDao.FindByTitle to actually take a title and return a
single permission
-fixed some indentation in SecurityService
-changed the toString() methods of roles/permissions
